### PR TITLE
[CIRCLE-20638] Handle all GitLab hooks with a single endpoint

### DIFF
--- a/src/test/java/com/circleci/connector/gitlab/singleorg/resources/HookResourceTest.java
+++ b/src/test/java/com/circleci/connector/gitlab/singleorg/resources/HookResourceTest.java
@@ -1,9 +1,12 @@
 package com.circleci.connector.gitlab.singleorg.resources;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.circleci.connector.gitlab.singleorg.api.HookResponse;
 import io.dropwizard.testing.FixtureHelpers;
+import java.util.Arrays;
+import java.util.List;
 import javax.ws.rs.WebApplicationException;
 import org.junit.jupiter.api.Test;
 
@@ -14,35 +17,62 @@ class HookResourceTest {
   @Test
   void weCanProcessTheHookFromGitlabDocs() throws Exception {
     HookResource hr = new HookResource(null);
-    HookResponse response = hr.processHook(gitLabPushHookFromDocs, null);
+    HookResponse response = hr.processHook(gitLabPushHookFromDocs, "Push Hook", null);
     assertEquals(HookResponse.Status.SUBMITTED, response.getStatus());
   }
 
   @Test
   void weCanProcessTheHookFromGitlabDocsWhenItSuppliesATokenAndWeAgree() throws Exception {
     HookResource hr = new HookResource("super-secret");
-    HookResponse response = hr.processHook(gitLabPushHookFromDocs, "super-secret");
+    HookResponse response = hr.processHook(gitLabPushHookFromDocs, "Push Hook", "super-secret");
     assertEquals(HookResponse.Status.SUBMITTED, response.getStatus());
   }
 
   @Test
   void weCanProcessTheHookFromGitlabDocsWhenItSuppliesATokenAndWeDoNotCare() throws Exception {
     HookResource hr = new HookResource(null);
-    HookResponse response = hr.processHook(gitLabPushHookFromDocs, "token-for-us-to-ignore");
+    HookResponse response =
+        hr.processHook(gitLabPushHookFromDocs, "Push Hook", "token-for-us-to-ignore");
     assertEquals(HookResponse.Status.SUBMITTED, response.getStatus());
   }
 
   @Test
   void weThrowA403IfTheGitlabTokenIsNotSupplied() throws Exception {
     HookResource hr = new HookResource("super-secret");
-    org.junit.jupiter.api.Assertions.assertThrows(
-        WebApplicationException.class, () -> hr.processHook(gitLabPushHookFromDocs, null));
+    assertThrows(
+        WebApplicationException.class,
+        () -> hr.processHook(gitLabPushHookFromDocs, "Push Hook", null));
   }
 
   @Test
   void weThrowA403IfTheGitlabTokenDoesNotMatch() throws Exception {
     HookResource hr = new HookResource("super-secret");
-    org.junit.jupiter.api.Assertions.assertThrows(
-        WebApplicationException.class, () -> hr.processHook(gitLabPushHookFromDocs, "wrong-token"));
+    assertThrows(
+        WebApplicationException.class,
+        () -> hr.processHook(gitLabPushHookFromDocs, "Push Hook", "wrong-token"));
+  }
+
+  @Test
+  void nonPushHookTypesReturnIgnored() throws Exception {
+    HookResource hr = new HookResource(null);
+    List<String> nonPushHookTypes =
+        Arrays.asList(
+            "Tag Push Hook",
+            "Issue Hook",
+            "Note Hook",
+            "Merge Request Hook",
+            "Wiki Page Hook",
+            "Pipeline Hook",
+            "Job Hook");
+    for (String nonPushHookType : nonPushHookTypes) {
+      HookResponse response = hr.processHook("{}", nonPushHookType, null);
+      assertEquals(HookResponse.Status.IGNORED, response.getStatus());
+    }
+  }
+
+  @Test
+  void ifThereIsNoGitlabEventHeaderWeThrow400() throws Exception {
+    HookResource hr = new HookResource(null);
+    assertThrows(WebApplicationException.class, () -> hr.processHook("{}", null, null));
   }
 }


### PR DESCRIPTION
Accept all hooks, but only really parse push hooks. Time and log everything.