### PR TITLE
Fix container tagging.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,8 @@ jobs:
           command: |
             (
               echo -n 'docker.pkg.github.com/'
-              echo -n 'circleci/gitlab-single-org-connector:'
+              echo -n 'circleci/gitlab-single-org-connector/'
+              echo -n 'gitlab-single-org-connector:'
               cat target/version
             ) > docker.tag
       - run:


### PR DESCRIPTION
Responding to:

```
name unknown: docker image push is only supported with a tag of the format :owner/:repo_name/:image_name.
Please add an image name to "circleci/gitlab-single-org-connector" tag. e.g. "circleci/gitlab-single-org-connector/<image_name>"
```