### PR TITLE
Add toString method to PushHook for more readable logs

### DIFF
--- a/src/main/java/com/circleci/connector/gitlab/singleorg/api/PushHook.java
+++ b/src/main/java/com/circleci/connector/gitlab/singleorg/api/PushHook.java
@@ -122,6 +122,21 @@ public class PushHook {
     project = p;
   }
 
+  @Override
+  public String toString() {
+    return "PushHook{" +
+            "id=" + id +
+            ", objectKind=" + objectKind +
+            ", before='" + before + '\'' +
+            ", after='" + after + '\'' +
+            ", ref='" + ref + '\'' +
+            ", project=" + project +
+            ", userId=" + userId +
+            ", userName='" + userName + '\'' +
+            ", userUsername='" + userUsername + '\'' +
+            '}';
+  }
+
   static class Project {
     @Range(min = 1)
     private int id;
@@ -160,6 +175,15 @@ public class PushHook {
     @JsonProperty("git_ssh_url")
     public void setGitSshUrl(String sshUrl) {
       gitSshUrl = sshUrl;
+    }
+
+    @Override
+    public String toString() {
+      return "Project{" +
+              "id=" + id +
+              ", name='" + name + '\'' +
+              ", gitSshUrl='" + gitSshUrl + '\'' +
+              '}';
     }
   }
 }


### PR DESCRIPTION
Results in logs like
```
 Received a hook: PushHook{id=e85b8b42-73a0-414a-b808-850713d5cf26, objectKind=push, before='95790bf891e76fee5e1747ab589903a6a1f80f22', after='da1560886d4f094c3e6c9ef40349f7d38b5d27d7', ref='refs/heads/master', project=Project{id=15, name='Diaspora', gitSshUrl='git@example.com:mike/diaspora.git'}, userId=4, userName='John Smith', userUsername='jsmith'}
```
instead of `Received a hook: com.circleci.connector.gitlab.singleorg.api.PushHook@25e2260`

**I don't think this is the way to go**

This is tedious to do, of course, so I think we should look for some annotation library or similar to simplify it (@c2nes had expressed a preference for https://immutables.github.io/, I think)

Or --alternatively-- we could call `MAPPER.writeValueToString` manually. This might be clearer/more explicit.